### PR TITLE
Update cmdk to match React 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "chokidar": "^4.0.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "cmdk": "1.0.0",
+    "cmdk": "^1.1.1",
     "concurrently": "^9.1.2",
     "date-fns": "^4.1.0",
     "embla-carousel-react": "^8.5.2",


### PR DESCRIPTION
This pull request intends to fix dependency conflict caused by `cmdk` and `react` dependencies.

> `cmdk@1.0.0` needs `react@"^18.0.0`

> `react@"^19.0.0` is installed in root `package.json`

Solution: update `cmdk` to latest `^1.1.1`

<img width="1239" alt="Снимок экрана 2025-03-22 в 14 29 47" src="https://github.com/user-attachments/assets/eb0b3c00-0539-4d3f-aef3-2c742ac1ef32" />
